### PR TITLE
Update README with new file direction removing the old one

### DIFF
--- a/preprocessing/sports/SAR_data/soccer/README.md
+++ b/preprocessing/sports/SAR_data/soccer/README.md
@@ -14,6 +14,7 @@ You can find detailed documentation on supported data providers [here](https://o
 For information on supported preprocessing methods, visit [this documentation](https://openstarlab.readthedocs.io/en/latest/Pre_Processing/Sports/SAR_data/Data_Format/Soccer/index.html). The available preprocessing methods are:
 
 - State Action Reward (SAR) Format
+- SAR-to-RL Dataset Conversion (SAR2RL)
 
 ## Examples
 Here are some examples of how to download and preprocess data:
@@ -29,10 +30,12 @@ Here are some examples of how to download and preprocess data:
 ## SAR-to-RL Dataset Conversion (DQN / QMIX)
 This section describes a SAR-to-RL dataset conversion step that formats SAR outputs (`events.jsonl`) into tensors used by
 DQN and QMIX training. This is a preprocessing/data-format step, not a training algorithm.
-The conversion script is `soccer_sar_to_rl_dataset.py`.
 
 This produces a single shared multi-agent dataset with:
 - `observation`: `(B, T, N, O)` (N=10 attackers)
 - `action`: `(B, T, N)` (discrete action ids; default vocab size 16 with `PAD=15`)
 - `reward`, `done`, `mask`: `(B, T)`
 - `onball_mask`: `(B, T, N)` (for masking unavailable actions)
+
+### Run via `SAR_data(...).preprocess_data()`
+You can run SAR2RL through the same entry point as SAR

--- a/preprocessing/sports/SAR_data/soccer/README.md
+++ b/preprocessing/sports/SAR_data/soccer/README.md
@@ -28,10 +28,6 @@ Here are some examples of how to download and preprocess data:
   - [Read the Docs Example](https://openstarlab.readthedocs.io/en/latest/Pre_Processing/Sports/SAR_data/Example/Soccer/Example_2/contents.html)
   - [Example Config File](https://github.com/open-starlab/PreProcessing/blob/master/example/config/statsbomb_skillcorner/preprocessing_statsbomb_skillcorner2024.json)
 
-- **RoboCup2D Data (SAR2RL):**
-  - [Read the Docs Example](https://openstarlab.readthedocs.io/en/latest/Pre_Processing/Sports/SAR_data/Data_Format/Soccer/index.html)
-  - [Example Action Map File](https://github.com/open-starlab/PreProcessing/blob/master/example/config/rl/action_map_dqn_qmix.json)
-
 ## SAR-to-RL Dataset Conversion (DQN / QMIX)
 This section describes a SAR-to-RL dataset conversion step that formats SAR outputs (`events.jsonl`) into tensors used by
 DQN and QMIX training. This is a preprocessing/data-format step, not a training algorithm.

--- a/preprocessing/sports/SAR_data/soccer/README.md
+++ b/preprocessing/sports/SAR_data/soccer/README.md
@@ -9,6 +9,7 @@ You can find detailed documentation on supported data providers [here](https://o
 
 - DataStadium
 - Statsbomb with Skillcorner Tracking Data
+- RoboCup2D (SAR2RL only)
 
 ## Supported Preprocessing Methods
 For information on supported preprocessing methods, visit [this documentation](https://openstarlab.readthedocs.io/en/latest/Pre_Processing/Sports/SAR_data/Data_Format/Soccer/index.html). The available preprocessing methods are:
@@ -26,6 +27,10 @@ Here are some examples of how to download and preprocess data:
 - **StatsBomb and SkillCorner Data:**
   - [Read the Docs Example](https://openstarlab.readthedocs.io/en/latest/Pre_Processing/Sports/SAR_data/Example/Soccer/Example_2/contents.html)
   - [Example Config File](https://github.com/open-starlab/PreProcessing/blob/master/example/config/statsbomb_skillcorner/preprocessing_statsbomb_skillcorner2024.json)
+
+- **RoboCup2D Data (SAR2RL):**
+  - [Read the Docs Example](https://openstarlab.readthedocs.io/en/latest/Pre_Processing/Sports/SAR_data/Data_Format/Soccer/index.html)
+  - [Example Action Map File](https://github.com/open-starlab/PreProcessing/blob/master/example/config/rl/action_map_dqn_qmix.json)
 
 ## SAR-to-RL Dataset Conversion (DQN / QMIX)
 This section describes a SAR-to-RL dataset conversion step that formats SAR outputs (`events.jsonl`) into tensors used by


### PR DESCRIPTION
- Removed the conversion script is [soccer_sar_to_rl_dataset.py](app://-/index.html?hostId=local#) direction.
- SAR2RL expects SAR outputs (events.jsonl) already exist.